### PR TITLE
fix: Can't auto load the env in some cases

### DIFF
--- a/src/PipManager/ViewModels/Pages/Environment/AddEnvironmentViewModel.cs
+++ b/src/PipManager/ViewModels/Pages/Environment/AddEnvironmentViewModel.cs
@@ -74,8 +74,8 @@ public partial class AddEnvironmentViewModel(INavigationService navigationServic
             var value = System.Environment.GetEnvironmentVariable("Path")!.Split(';');
             foreach (var item in value)
             {
-                if (!item.Contains("Python") || item.Contains("Scripts") ||
-                    !File.Exists(Path.Combine(item, "python.exe"))) continue;
+                if (!File.Exists(Path.Combine(item, "python.exe")))
+                    continue;
                 var environmentItem =
                     _configurationService.GetEnvironmentItem(Path.Combine(item, "python.exe"));
                 if (environmentItem == null) continue;


### PR DESCRIPTION
In previous version, we only load the path with 'Python','Scripts'. But this is not the case for everyone. 
Fixed by a more proper way to detect the enviroments.